### PR TITLE
Support automated testing on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,11 @@ pip-log.txt
 #Translations
 *.mo
 
-#Mr Developer
+# Mr Developer
 .mr.developer.cfg
 /.settings
 /.project
 /.pydevproject
+
+# gedit
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 python:
+    - "2.6"
     - "2.7"
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: python
 python:
     - "2.6"
     - "2.7"
+
 # command to install dependencies
 install:
-    - pip install -r requirements.txt --use-mirrors
+    - sudo apt-get install libboost-python-dev
+    - pip install -r requirements-test.txt --use-mirrors
     - pip install . --use-mirrors
-# # command to run tests
+
+# command to run tests
 script:
     - cd src/test
     - python pyscxmlTest.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 # command to install dependencies
 install:
     - sudo apt-get install libboost-python-dev libv8-dev
+    - pip install -r requirements.txt --use-mirrors
     - pip install -r requirements-test.txt --use-mirrors
     - pip install . --use-mirrors
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # command to install dependencies
 install:
-    - sudo apt-get -q install libboost-python-dev libv8-dev
+    - sudo apt-get -qq install libboost-python-dev libv8-dev
     - wget https://github.com/downloads/pyjs/pyjs/pyv8-build.2012-05-15.tar.gz
     - tar xzvf pyv8-build.2012-05-15.tar.gz
     - pip install -r requirements.txt --use-mirrors

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: python
 python:
-    - "2.6"
     - "2.7"
 
 # command to install dependencies
 install:
     - sudo apt-get install libboost-python-dev libv8-dev
+    - wget https://github.com/downloads/pyjs/pyjs/pyv8-build.2012-05-15.tar.gz
+    - tar xzvf pyv8-build.2012-05-15.tar.gz
     - pip install -r requirements.txt --use-mirrors
-    - pip install -r requirements-test.txt --use-mirrors
     - pip install . --use-mirrors
 
 # command to run tests
 script:
+    - export PYTHONPATH=`pwd`/pyv8-build
     - cd src/test
     - python pyscxmlTest.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # command to install dependencies
 install:
-    - sudo apt-get install libboost-python-dev
+    - sudo apt-get install libboost-python-dev libb8-dev
     - pip install -r requirements-test.txt --use-mirrors
     - pip install . --use-mirrors
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+    - "2.6"
+    - "2.7"
+# command to install dependencies
+install:
+    - pip install -r requirements.txt --use-mirrors
+# # command to run tests
+script:
+    - cd src/test
+    - python pyscxmlTest.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 # command to install dependencies
 install:
-    - sudo apt-get install libboost-python-dev libb8-dev
+    - sudo apt-get install libboost-python-dev libv8-dev
     - pip install -r requirements-test.txt --use-mirrors
     - pip install . --use-mirrors
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 # command to install dependencies
 install:
     - pip install -r requirements.txt --use-mirrors
+    - pip install . --use-mirrors
 # # command to run tests
 script:
     - cd src/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
 
 # command to install dependencies
 install:
-    - sudo apt-get install libboost-python-dev libv8-dev
+    - sudo apt-get -q install libboost-python-dev libv8-dev
     - wget https://github.com/downloads/pyjs/pyjs/pyv8-build.2012-05-15.tar.gz
     - tar xzvf pyv8-build.2012-05-15.tar.gz
     - pip install -r requirements.txt --use-mirrors

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+PyV8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,0 @@
--r requirements.txt
-PyV8

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ Louie
 eventlet
 restlib
 suds
+lxml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+Louie
+eventlet
+restlib
+suds
+


### PR DESCRIPTION
These commits add the `.travis.yml` and updated requirements file to support running on travis.

It runs against 2.7, but not against 2.6: [![Build Status](https://secure.travis-ci.org/bollwyvl/PySCXML.png)](http://travis-ci.org/bollwyvl/PySCXML)

The [2.6 fail](http://travis-ci.org/#!/bollwyvl/PySCXML/jobs/1641501/L184) says `JSContext` is not accessible... which may be related to the issue below.

For PyV8 (required for the full test suite) I have included the [technique from pyjs](https://groups.google.com/forum/?fromgroups#!topic/pyjs-users/XlBgl19Rnfo), and am grabbing their [pre-compiled library from github](https://github.com/pyjs/pyjs/downloads).

At some future point, it may make sense to keep one of these around for pyscxml, at least until PyV8 installs cleanly on travis.
