### PR TITLE
decorator for defining custiom <send> types

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Since the websocket server sends events to its clients in the SCXML messaging XM
 
 ##Extending PySCXML##
 
-According to the principle expressed in http://www.w3.org/TR/scxml/#extensibility, of the extensibility of executable content, PySCXML provides two convenient decorators for the purpose of defining executable content.
+According to the principle expressed in http://www.w3.org/TR/scxml/#extensibility, of the extensibility of executable content, PySCXML provides few convenient decorators for the purpose of defining executable content.
 
 The first, `custom_executable`, defines a handler function for all nodes of a particular namespace. All you have to do is decorate a handler function, like so:
 
@@ -458,6 +458,25 @@ The first, `custom_executable`, defines a handler function for all nodes of a pa
 
 
 The decorator takes a parameter, the namespace, and the result is that each executable node in that namespace will be passed through your function, as an  `xml.etree.ElementTree.Element` object. The handler throws away return values. 
+
+
+Extending the '<send />' tag to support more transport/ioprocessor types (i.e. <send type="my_sendtype"/>) is possible via another decorator: `custom_sendtype`. Here is a simplified example:
+
+        from scmxl.pyscxml import custom_sendtype
+        @custom_sendtype('my_sendtype')
+        def my_sender(msg, datamodel):
+            # create some custom transport to the target
+            target = msg.target
+            transport = create_transport(target)
+            msg_serialized = some_serialization(msg)
+            transport.send(msg_serialized)
+
+
+Where 'msg' argument is object instance of type ScxmlMessage (see: scxml.eventprocessor.ScxmlMessage) and 'datamodel' is the sending session *DataModel (e.g. PythonDataModel) instance.
+
+
+
+WARNING: The following part of this section refers to feature that seems to be obsolete from some version on.
 
 To simplify the addition of executable content that result in events being sent, a preprocessor decorator has been added. With the preprocessor, you can replace any node in you scxml document with any other nodes. the syntax is similar to the one above. Here, however, we return an xml string with which to replace the incoming node. A typical use would be to replace `<my_ns:send_to_service targetexpr="my_custom_service" />` with its `<send />` equivalent, which might be `<send type="basichttp" target="my_custom_service" namelist="param1 param2" />`. We'd write:
 

--- a/src/scxml/errors.py
+++ b/src/scxml/errors.py
@@ -30,7 +30,7 @@ class ExecutableError(CompositeError):
     def __str__(self):
         name = type(self.exception).__name__
         article = "An" if name[0].lower() in "aieou" else "A" 
-        return "%s %s occurred when evaluating %s on line %s:\n    %s  " \
+        return "%s '%s' occurred when evaluating '%s' on line %s:\n    %s  " \
             % (article, name, split_ns(self.elem)[1], self.elem.sourceline, self.exception)
 
 class IllegalLocationError(AtomicError):

--- a/src/scxml/pyscxml.py
+++ b/src/scxml/pyscxml.py
@@ -327,7 +327,15 @@ class custom_executable(object):
         compiler.custom_exec_mapping[self.namespace] = f
         return f
     
-    
+class custom_sendtype(object):
+    '''A decorator for defining custom send types'''
+    def __init__(self, sendtype):
+        self.sendtype = sendtype
+
+    def __call__(self, fun):
+        compiler.custom_sendtype_mapping[self.sendtype] = fun
+        return fun
+
 #class preprocessor(object):
 #    '''A decorator for defining replacing xml elements of a 
 #    particular namespace with other markup. '''
@@ -353,7 +361,15 @@ def register_datamodel(id, klass):
     compiler.datamodel_mapping[id] = klass
 
     
-__all__ = ["StateMachine", "MultiSession", "custom_executable", "preprocessor", "expr_evaluator", "expr_exec"]
+__all__ = [
+    "StateMachine",
+    "MultiSession",
+    "custom_executable",
+    "preprocessor",
+    "expr_evaluator",
+    "expr_exec",
+    "custom_sendtype"
+]
 
 if __name__ == "__main__":
     os.environ["PYSCXMLPATH"] = "../../w3c_tests/:../../unittest_xml:../../resources"

--- a/src/scxml/pyscxml.py
+++ b/src/scxml/pyscxml.py
@@ -273,7 +273,12 @@ class MultiSession(object):
          '''
         assert source or self.default_scxml_source
         if isinstance(source, basestring):
-            sm = StateMachine(source or self.default_scxml_source, sessionid=sessionid, default_datamodel=self.default_datamodel,setup_session=False)
+            log_func = self.log_function or default_logfunction
+            sm = StateMachine(source or self.default_scxml_source,
+                                sessionid=sessionid,
+                                default_datamodel=self.default_datamodel,
+                                setup_session=False,
+                                log_function=log_func)
         else:
             sm = source # source is assumed to be a StateMachine instance
         self.sm_mapping[sessionid] = sm


### PR DESCRIPTION
I thought it will be nice if one can define custom transports without the need to hack in the main library code. Tried to follow the current style with decorators but more complete solution should be some api/base class for pluggable transports with methods for both sending and receiving events from external sources. I may consider implementing such interface in future if you are interested too.
Also did a small change on some exception messages. It was difficult for me to hack in with exceptions catched on so many places and layers.
